### PR TITLE
🐛 [Minikube] Update minikube version

### DIFF
--- a/minikube/action.yml
+++ b/minikube/action.yml
@@ -7,7 +7,7 @@ inputs:
   minikube-version:
     description: 'Minikube version to install'
     required: false
-    default: '1.4.0'
+    default: '1.7.3'
   k8s-version:
     description: 'Kubernetes version to install'
     required: false

--- a/minikube/src/index.js
+++ b/minikube/src/index.js
@@ -9,13 +9,13 @@ try {
   console.log(`Downloading Minikube...`)
   var lastCommandRunning = spawnSync('curl', [
     '-LO',
-    `https://storage.googleapis.com/minikube/releases/latest/minikube_${minikubeVersion}.deb`,
+    `https://github.com/kubernetes/minikube/releases/download/v${minikubeVersion}/minikube_${minikubeVersion}-0_amd64.deb`,
   ])
   console.log(`${lastCommandRunning.stdout.toString()}`)
   console.error(`${lastCommandRunning.stderr.toString()}`)
 
   console.log(`Installing Minikube...`)
-  lastCommandRunning = spawnSync('sudo', ['dpkg', '-i', `minikube_${minikubeVersion}.deb`])
+  lastCommandRunning = spawnSync('sudo', ['dpkg', '-i', `minikube_${minikubeVersion}-0_amd64.deb`])
   console.log(`${lastCommandRunning.stdout.toString()}`)
   console.error(`${lastCommandRunning.stderr.toString()}`)
 


### PR DESCRIPTION
Update minikube version and use Github releases.

~The `none` driver leads to data loss. Minikube **might** delete docker
images along the way. So custom built Github Actions in the beginning of the
test suite run might not be available anymore, leading to the following
error:~

```
Unable to find image 'e87b52:89cfea809dd54275bad1ef69bbc9fb07' locally
/usr/bin/docker: Error response from daemon: pull access denied for e87b52, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See '/usr/bin/docker run --help'.
```